### PR TITLE
添加安装步骤细节

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Rimerc 是为了解决 Rime 新手配置难题，提供自己整理和不断磨�
 
    该步骤完成后，对于Linux和Mac OS，脚本会自动备份已有配置文件，并部署新的配置文件。对于Android和Windows系统，需要进行步骤3
 
-3. 对于Android和Windows，需要手动将`trime`或`weasel`文件夹内的所有内容复制到相应平台的配置路径所在文件夹内（见上）
+3. 对于Android和Windows，需要手动将脚本生成的`release/trime`或`release/weasel`文件夹内的所有内容复制到相应平台的配置路径所在文件夹内（见上）
 
 
 ### 手动方式

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-### rimerc: rimer's dictionary & config
+# rimerc: rimer's dictionary & config
 
 **让更多的人快速高效地享受 Rime 输入法带来的乐趣 🎉🎉🎉**
 
-#### 由来
+## 由来
 
 最开始接触 Rime 平台输入法时，看中其**隐私安全性**，使用时却遇到很多问题
 
@@ -10,7 +10,7 @@
 
 自己不断摸索的过程中萌生分享配置，帮助大家快速入手 Rime 输入法的想法
 
-#### 隐私
+## 隐私
 
 输入法作为日常使用的必备软件，涉及的数据极其**敏感和隐私**，目前商用输入法
 
@@ -20,7 +20,7 @@
 
 困难等问题，所以把自己整理的配置分享给大家，让大家使用起来更加方便和便捷
 
-#### 简介
+## 简介
 
 Rimerc 是为了解决 Rime 新手配置难题，提供自己整理和不断磨合的配置文件
 
@@ -28,7 +28,7 @@ Rimerc 是为了解决 Rime 新手配置难题，提供自己整理和不断磨�
 
 整理和分享自己磨合的配置，为其他小白用户解决配置难题，推广 Rime 的使用
 
-#### 特点
+## 特点
 
 - 开箱即用且词库丰富
 - 全平台配置文件支持
@@ -36,26 +36,9 @@ Rimerc 是为了解决 Rime 新手配置难题，提供自己整理和不断磨�
 - 均经过自己整理和磨合
 - 适合不熟悉配置的新手
 
-#### 用法
+## 用法
 
-##### 脚本方式
-
-推荐使用脚本方式，具有自动解压、备份和重新部署功能，更加高效快捷
-
- ``` bash
- # usage of rimerc
- git clone https://github.com/Bambooin/rimerc.git
- cd rimerc
- # pick one of your rime: fcitx, fcitx5, ibus or squirrel
- ./rimerc.sh fcitx5
- ```
-
-##### 手动方式
-1. **备份自己原有配置文件**
-2. 下载最新版本到相应目录
-3. 重新部署即可流畅使用
-
-##### 配置路径
+### 配置路径
 
 - Android
   - [Trime](https://github.com/osfans/trime): /sdcard/rime
@@ -63,7 +46,7 @@ Rimerc 是为了解决 Rime 新手配置难题，提供自己整理和不断磨�
 - macOS
   - [Squirrel](https://github.com/rime/squirrel): ~/Library/Rime
 
-- UN*X
+- UN\*X
   - [Fcitx](https://github.com/fcitx/fcitx-rime): ~/.config/fcitx/rime
   - [Fcitx5](https://github.com/fcitx/fcitx5-rime): ~/.local/share/fcitx5/rime
   - [IBus](https://github.com/rime/ibus-rime): ~/.config/ibus/rime
@@ -71,19 +54,66 @@ Rimerc 是为了解决 Rime 新手配置难题，提供自己整理和不断磨�
 - Windows
   - [Weasel](https://github.com/rime/weasel): %AppData%\Rime
 
-##### 详细步骤
+### 脚本方式
 
-以 Android 平台为例 (Android 内存需大于 2G，部署前清除系统缓存)
+推荐使用脚本方式，具有自动解压、备份和重新部署功能，更加高效快捷
 
-1. 为了保留自己的配置文件，需要把 rime 重命名为 unrime
-2. 新建一个空目录 rime，复制 tirme 里面的文件到该目录
-3. 进入应用，**输入配置-->恢复默认设置-->勾选所有选项**
-4. 重新部署(**由于词库文件很大，部署运行时间较长，请耐心等待**)
-5. 部署完成后 build 目录里面生成各种 bin 文件即可认为部署成功
-6. 进入系统设置启用并选择 Trime 输入法，即可享受 Rime 输入法
-7. 若是配置不符合预期，可以删除 rime 目录，恢复自己的配置即可
+需要Linux、Mac OS或其它具有(bash) shell的终端执行下列命令
 
-#### 致谢
+1. 克隆本仓库，进入文件夹
+
+   ``` bash
+   git clone https://github.com/Bambooin/rimerc.git
+   cd rimerc
+   ```
+
+2. 准备所有相关的配置文件，将下列命令中的`<variant>`改为你将要使用的平台：fcitx、fcitx5、ibus、squirrel、trime或weasel
+
+   ```
+   ./rimerc.sh <variant>
+   ```
+
+   该步骤完成后，对于Linux和Mac OS，脚本会自动备份已有配置文件，并部署新的配置文件。对于Android和Windows系统，需要进行步骤3
+
+3. 对于Android和Windows，需要手动将`trime`或`weasel`文件夹内的所有内容复制到相应平台的配置路径所在文件夹内（见上）
+
+
+### 手动方式
+
+准备：
+
+1. **备份自己原有配置文件**，如将原配置文件夹`rime`重命名为`rime.old`。
+2. 下载最新版本到相应目录，可使用git克隆，或者下载zip压缩包（Github页面提供该功能）后在本地解压
+3. 进入`rimerc`文件夹（下载zip压缩包则会解压为`rimerc-master`文件夹）
+
+打包：
+
+4. 下列三个文件夹内的内容是每一个平台都需要（推荐）的：
+
+   - `common/`：基础配置文件
+   - `easy_en/`：英文输入
+   - `luna_pinyin/`：中文输入
+
+   将上述每一个文件夹内的文件复制到你所使用平台的配置路径文件夹（见上）内
+5. 将你所使用平台，即fcitx、fcitx5、ibus、squirrel、trime或weasel，相应文件夹中的文件复制到你所使用平台的配置路径文件夹（见上）内
+
+部署：
+
+6. 重新部署(**由于词库文件很大，部署运行时间较长，请耐心等待**)
+
+   部署完成后，配置路径下`build`目录里面生成各种`*.bin`文件即可认为部署成功
+7. 若本配置文件使用过程出现任何问题，尝试：
+
+   - 清除应用的系统缓存（如安卓系统）
+   - 回复默认设置（如安卓系统：进入应用，**输入配置-->恢复默认设置-->勾选所有选项**）
+
+   后重新部署（步骤6）
+
+恢复：
+
+8. 若是配置不符合预期，可以删除 rime 目录，恢复自己的配置即可
+
+## 致谢
 
 **所有词库和配置文件均从互联网上获取并精心整理、磨合和改善**
 - Rime: 感谢 [lotem](https://github.com/lotem) 提供的优秀输入法平台


### PR DESCRIPTION
本仓库在很多场合被介绍给不会配置rime的新手用户，应该更加“傻瓜向”。不过原安装步骤说明不是很清楚，可能不容易照着做，因此做了大幅修改，希望接受。

- 对于脚本安装方式：
  - 列举所有平台。原步骤列举平台不全，缺少trime或weasel。虽然无法自动部署，但脚本确实可以覆盖二者平台
  - 详细、明确地说明脚本的功能，让用户了解情况
- 对于手动安装方式：
  - 详细说明每一个步骤，让其他用户能清晰地跟随执行
  - 表明common、easy_en、luna_pinyin三个文件夹为共需部分（安卓案例中只提到复制trime一个文件夹，是不够的，至少与脚本的行为不一致）
  - 去除了安卓的例子，融入至各步骤中
- 修改了各标题等级。4、5级比正文都小了，如需要，可以用粗体代替